### PR TITLE
Use `st.x` to plot greyscale values along x

### DIFF
--- a/05/linear.frag
+++ b/05/linear.frag
@@ -13,13 +13,12 @@ float plot(vec2 st, float pct){
 }
 
 void main() {
-	vec2 st = gl_FragCoord.xy/u_resolution;
+    vec2 st = gl_FragCoord.xy/u_resolution;
 
-    float y = st.x;
-
-    vec3 color = vec3(y);
+    vec3 color = vec3(st.x);
     
     // Plot a line
+    float y = st.x;
     float pct = plot(st,y);
     color = (1.0-pct)*color+pct*vec3(0.0,1.0,0.0);
     


### PR DESCRIPTION
Instead of the previous version, which was confusing because the variable `y` was used to determine the greyscale value of each column (x coordinate). This version moves the declaration of `y` down to the block in which it's used, the line plot.